### PR TITLE
Onboarding IPC-ification, initialization fixes

### DIFF
--- a/src/container/init.nim
+++ b/src/container/init.nim
@@ -1,6 +1,9 @@
 import std/[os, logging]
 import
-  ./[lxc, configuration, cpu, drivers, image_downloader, hal, rootfs, configuration, network]
+  ./[
+    lxc, configuration, cpu, drivers, image_downloader, hal, rootfs, configuration,
+    network,
+  ]
 import ../argparser
 
 proc setupConfig*(input: Input): bool =

--- a/src/container/init.nim
+++ b/src/container/init.nim
@@ -38,6 +38,8 @@ proc initialize*(input: Input) =
   discard existsOrCreateDir(config.overlayRw / "system")
   discard existsOrCreateDir(config.overlayRw / "vendor")
   discard existsOrCreateDir(config.work / "images")
+  discard existsOrCreateDir(config.lxc)
+  discard existsOrCreateDir(config.lxc / "equinox")
 
   mountRootfs(input, config.imagesPath)
   generateSessionLxcConfig()

--- a/src/container/init.nim
+++ b/src/container/init.nim
@@ -41,6 +41,7 @@ proc initialize*(input: Input) =
 
   mountRootfs(input, config.imagesPath)
   generateSessionLxcConfig()
+  setLxcConfig()
   startLxcContainer(input)
 
   let imagesExist =
@@ -50,7 +51,6 @@ proc initialize*(input: Input) =
     let pair = getImages()
     pair.downloadImages()
 
-  setLxcConfig()
   waitForContainerBoot()
   makeBaseProps(input)
   stopLxcContainer() # stop it afterwards

--- a/src/container/init.nim
+++ b/src/container/init.nim
@@ -1,6 +1,6 @@
 import std/[os, logging]
 import
-  ./[lxc, configuration, cpu, drivers, image_downloader, hal, rootfs, configuration]
+  ./[lxc, configuration, cpu, drivers, image_downloader, hal, rootfs, configuration, network]
 import ../argparser
 
 proc setupConfig*(input: Input): bool =
@@ -41,6 +41,7 @@ proc initialize*(input: Input) =
   discard existsOrCreateDir(config.lxc)
   discard existsOrCreateDir(config.lxc / "equinox")
 
+  initNetworkService()
   mountRootfs(input, config.imagesPath)
   generateSessionLxcConfig()
   setLxcConfig()
@@ -56,4 +57,5 @@ proc initialize*(input: Input) =
   waitForContainerBoot()
   makeBaseProps(input)
   stopLxcContainer() # stop it afterwards
+  stopNetworkService()
   info "Initialized Equinox successfully."

--- a/src/gui/apk_install.nim
+++ b/src/gui/apk_install.nim
@@ -191,7 +191,7 @@ proc runApkFetcher*() =
 
   # If we're the parent - we launch the GUI.
   # Else, we'll sit around waiting for commands to act upon.
-  if pid == 0:
+  if pid != 0:
     var buff: array[1, uint8]
     buff[0] = (uint8) FetcherMagic.Fetch
     discard write(pair[0], buff[0].addr, 1)

--- a/src/gui/launcher.nim
+++ b/src/gui/launcher.nim
@@ -204,7 +204,7 @@ proc runLauncher*() =
 
   # If we're the parent - we launch the GUI.
   # Else, we'll sit around waiting for commands to act upon.
-  if pid == 0:
+  if pid != 0:
     adw.brew(gui(Launcher(sock = pair[0])))
 
     # Tell the child to die.

--- a/src/gui/onboard.nim
+++ b/src/gui/onboard.nim
@@ -16,7 +16,7 @@ type
     InitEquinox = 0 ## Call the Equinox initialization command
     InitSuccess = 1 ## Successful initialization has taken place
     InitFailure = 2 ## Failed initialization
-    Die = 3         ## Kill yourself.
+    Die = 3 ## Kill yourself.
 
 viewable OnboardingApp:
   description:
@@ -43,8 +43,10 @@ viewable OnboardingApp:
   consentFail:
     string = ""
 
-  sock: cint
-  showSpinner: bool = false
+  sock:
+    cint
+  showSpinner:
+    bool = false
 
 let env = getXdgEnv()
 
@@ -61,22 +63,19 @@ method view(app: OnboardingAppState): Widget =
 
     var buff: array[1, uint8]
     discard read(app.sock, buff[0].addr, 1)
-    
+
     case (OnboardMagic) buff[0]
-    of OnboardMagic.InitEquinox, OnboardMagic.Die: discard
+    of OnboardMagic.InitEquinox, OnboardMagic.Die:
+      discard
     of OnboardMagic.InitFailure:
       warn "gui/onboard: TODO: init failure screen"
     of OnboardMagic.InitSuccess:
       let gsfId =
-        &readOutput(
-          "pkexec", env.equinoxPath & " get-gsf-id --user:" & env.user
-        )
+        &readOutput("pkexec", env.equinoxPath & " get-gsf-id --user:" & env.user)
 
       debug "gui/onboard: gsf id = " & gsfId
 
-      openDefaultBrowser(
-        "https://play.google.com/about/play-terms/index.html"
-      )
+      openDefaultBrowser("https://play.google.com/about/play-terms/index.html")
       openDefaultBrowser("https://www.google.com/android/uncertified")
       copyText(gsfId)
 
@@ -163,7 +162,7 @@ method view(app: OnboardingAppState): Widget =
             text =
               "Welcome to Equinox. Press the button below to start the setup.\nKeep in mind that this can take a minute."
             margin = 24
-          
+
           if app.showSpinner:
             AdwSpinner()
 
@@ -191,7 +190,7 @@ method view(app: OnboardingAppState): Widget =
                 var buff: array[1, uint8]
                 buff[0] = (uint8) OnboardMagic.InitEquinox
                 discard write(app.sock, buff[0].addr, 1)
-                
+
                 app.showSpinner = true
                 discard addGlobalIdleTask(waitForInit)
 
@@ -214,10 +213,11 @@ proc waitForCommands*(fd: cint) =
       runCmd(
         "pkexec",
         env.equinoxPath & " init --xdg-runtime-dir:" & env.runtimeDir &
-        " --verbose --wayland-display:" & env.waylandDisplay & " --user:" & env.user &
-        " --uid:" & $getuid() & " --gid:" & $getgid(),
+          " --verbose --wayland-display:" & env.waylandDisplay & " --user:" & env.user &
+          " --uid:" & $getuid() & " --gid:" & $getgid(),
       )
-    of OnboardMagic.InitFailure, OnboardMagic.InitSuccess: discard
+    of OnboardMagic.InitFailure, OnboardMagic.InitSuccess:
+      discard
     of OnboardMagic.Die:
       running = false
 
@@ -229,7 +229,7 @@ proc runOnboardingApp*() =
       "socketpair() returned " & $status & ": " & $strerror(errno) & " (errno " & $errno &
         ')',
     )
-  
+
   let pid = fork()
 
   if pid == 0:

--- a/src/gui/onboard.nim
+++ b/src/gui/onboard.nim
@@ -6,7 +6,17 @@ import
   ./envparser,
   ../container/[lxc, sugar, certification],
   ../container/utils/exec,
+  ../bindings/libadwaita,
   ./clipboard
+
+type
+  CantMakeSocketPair = object of OSError
+
+  OnboardMagic {.pure, size: sizeof(uint8).} = enum
+    InitEquinox = 0 ## Call the Equinox initialization command
+    InitSuccess = 1 ## Successful initialization has taken place
+    InitFailure = 2 ## Failed initialization
+    Die = 3         ## Kill yourself.
 
 viewable OnboardingApp:
   description:
@@ -33,20 +43,82 @@ viewable OnboardingApp:
   consentFail:
     string = ""
 
-  #my code sucks
-  erm_guh:
-    string =
-      "equinox init --xdg-runtime-dir:A --wayland-display:B --user:C --uid:D --gid:E"
-  runtime:
-    string = "--xdg-runtime-dir:"
-  wayland:
-    string = "--wayland-display:"
-  user:
-    string = "--user:"
+  sock: cint
+  showSpinner: bool = false
 
 let env = getXdgEnv()
 
 method view(app: OnboardingAppState): Widget =
+  proc waitForInit(): bool =
+    var readfds: TFdSet
+    var timeout: Timeval
+
+    FD_ZERO(readfds)
+    FD_SET(app.sock, readfds)
+    var ret = select(app.sock + 1.cint, readfds.addr, nil, nil, timeout.addr)
+    if ret < 0 or not bool(FD_ISSET(app.sock, readfds)):
+      return true
+
+    var buff: array[1, uint8]
+    discard read(app.sock, buff[0].addr, 1)
+    
+    case (OnboardMagic) buff[0]
+    of OnboardMagic.InitEquinox, OnboardMagic.Die: discard
+    of OnboardMagic.InitFailure:
+      warn "gui/onboard: TODO: init failure screen"
+    of OnboardMagic.InitSuccess:
+      let gsfId =
+        &readOutput(
+          "pkexec", env.equinoxPath & " get-gsf-id --user:" & env.user
+        )
+
+      debug "gui/onboard: gsf id = " & gsfId
+
+      openDefaultBrowser(
+        "https://play.google.com/about/play-terms/index.html"
+      )
+      openDefaultBrowser("https://www.google.com/android/uncertified")
+      copyText(gsfId)
+
+      discard app.open:
+        gui:
+          Window:
+            title = "Setup Flow"
+            defaultSize = (300, 450)
+            HeaderBar {.addTitlebar.}:
+              style = [HeaderBarFlat]
+
+            Clamp:
+              maximumSize = 450
+              margin = 12
+
+              Box:
+                orient = OrientY
+                spacing = 12
+
+                ActionRow:
+                  title =
+                    "You're about to interact with Google's Play Store, and as such, you will be subject to their terms of service."
+                  subtitle =
+                    "Make sure you've read the Google Play Terms of Service. It has just been opened in your browser."
+
+                Label:
+                  text =
+                    "Equinox's GSF ID has been copied to your clipboard. Paste it in your browser and complete the Captcha to continue."
+                  margin = 24
+
+                Box {.hAlign: AlignCenter, vAlign: AlignCenter.}:
+                  Button:
+                    style = [ButtonPill, ButtonSuggested]
+                    text = "Complete Setup"
+                    tooltip =
+                      "Click this button when you are done with the steps above."
+
+                    proc clicked() =
+                      app.closeWindow()
+
+    return false
+
   result = gui:
     Window:
       defaultSize = (300, 400)
@@ -64,7 +136,6 @@ method view(app: OnboardingAppState): Widget =
 
           PreferencesGroup {.expand: false.}:
             title = "Onboarding"
-            #description = "Losing it"
 
             ActionRow:
               title = "I Consent"
@@ -90,8 +161,11 @@ method view(app: OnboardingAppState): Widget =
 
           Label:
             text =
-              "Welcome to Equinox. Press the button below to start the setup.\nKeep in mind that this can take upwards of 10 minutes, depending on your internet connection.\nThis application will be fully unresponsive until it is done. Do not exit it!"
+              "Welcome to Equinox. Press the button below to start the setup.\nKeep in mind that this can take a minute."
             margin = 24
+          
+          if app.showSpinner:
+            AdwSpinner()
 
           Label:
             text = app.consentFail
@@ -114,72 +188,65 @@ method view(app: OnboardingAppState): Widget =
                   return
 
                 # Init command
-                runCmd(
-                  "pkexec",
-                  env.equinoxPath & " init --xdg-runtime-dir:" & env.runtimeDir &
-                    " --wayland-display:" & env.waylandDisplay & " --user:" & env.user &
-                    " --uid:" & $getuid() & " --gid:" & $getgid(),
-                )
+                var buff: array[1, uint8]
+                buff[0] = (uint8) OnboardMagic.InitEquinox
+                discard write(app.sock, buff[0].addr, 1)
+                
+                app.showSpinner = true
+                discard addGlobalIdleTask(waitForInit)
 
-                let gsfId =
-                  &readOutput(
-                    "pkexec", env.equinoxPath & " get-gsf-id --user:" & env.user
-                  )
-                debug "gui/onboard: gsf id = " & gsfId
+proc waitForCommands*(fd: cint) =
+  var running = true
+  while running:
+    debug "launcher/child: waiting for opcode"
+    var opcode: array[1, byte]
+    if (let status = read(fd, opcode[0].addr, 1); status != 1):
+      error "launcher/child: read() returned " & $status & ": " & $strerror(errno) &
+        " (errno " & $errno & ')'
+      error "launcher/child: i think the launcher has crashed or something idk"
+      break
 
-                openDefaultBrowser(
-                  "https://play.google.com/about/play-terms/index.html"
-                )
-                openDefaultBrowser("https://www.google.com/android/uncertified")
-                copyText(gsfId)
+    var op = cast[OnboardMagic](cast[uint8](opcode[0]))
+    debug "launcher/child: opcode -> " & $op
 
-                discard app.open:
-                  gui:
-                    Window:
-                      title = "Setup Flow"
-                      defaultSize = (300, 450)
-                      HeaderBar {.addTitlebar.}:
-                        style = [HeaderBarFlat]
-
-                      Clamp:
-                        maximumSize = 450
-                        margin = 12
-
-                        Box:
-                          orient = OrientY
-                          spacing = 12
-
-                          ActionRow:
-                            title =
-                              "You're about to interact with Google's Play Store, and as such, you will be subject to their terms of service."
-                            subtitle =
-                              "Make sure you've read the Google Play Terms of Service. It has just been opened in your browser."
-
-                          Label:
-                            text =
-                              "Equinox's GSF ID has been copied to your clipboard. Paste it in your browser and complete the Captcha to continue."
-                            margin = 24
-
-                          Box {.hAlign: AlignCenter, vAlign: AlignCenter.}:
-                            Button:
-                              style = [ButtonPill, ButtonSuggested]
-                              text = "Complete Setup"
-                              tooltip =
-                                "Click this button when you are done with the steps above."
-
-                              proc clicked() =
-                                app.closeWindow()
+    case op
+    of OnboardMagic.InitEquinox:
+      runCmd(
+        "pkexec",
+        env.equinoxPath & " init --xdg-runtime-dir:" & env.runtimeDir &
+        " --verbose --wayland-display:" & env.waylandDisplay & " --user:" & env.user &
+        " --uid:" & $getuid() & " --gid:" & $getgid(),
+      )
+    of OnboardMagic.InitFailure, OnboardMagic.InitSuccess: discard
+    of OnboardMagic.Die:
+      running = false
 
 proc runOnboardingApp*() =
-  adw.brew(
-    gui(OnboardingApp()),
-    stylesheets = [
-      newStylesheet(
-        """
-      .warning-label {
-        color: #ff938b;
-      }
-    """
-      )
-    ],
-  )
+  var pair: array[2, cint]
+  if (let status = socketpair(AF_UNIX, SOCK_STREAM, 0, pair); status != 0):
+    raise newException(
+      CantMakeSocketPair,
+      "socketpair() returned " & $status & ": " & $strerror(errno) & " (errno " & $errno &
+        ')',
+    )
+  
+  let pid = fork()
+
+  if pid == 0:
+    waitForCommands(pair[0])
+  else:
+    adw.brew(
+      gui(OnboardingApp(sock = pair[1])),
+      stylesheets = [
+        newStylesheet(
+          """
+        .warning-label {
+          color: #ff938b;
+        }
+      """
+        )
+      ],
+    )
+    var buff: array[1, uint8]
+    buff[0] = (uint8) OnboardMagic.Die
+    discard pair[1].write(buff[0].addr, 1)


### PR DESCRIPTION
- **fix: init: don't start container prior to config generation**
- **feat: ipc-ify the onboarding screen**
- **fix: init: create container config directory**
- **fix: init: initialize network prior to container first boot**
- **chore: format**

The onboarding GUI is waaaayyy less janky now. The initialization sequence is also much less error prone.
