### PR TITLE
fix(gui): fix failing to find equinox

### DIFF
--- a/src/gui/envparser.nim
+++ b/src/gui/envparser.nim
@@ -1,4 +1,4 @@
-import std/[strformat, os, options]
+import std/[strformat, os, options, logging]
 import pkg/[colored_logger]
 import ../[argparser]
 
@@ -23,7 +23,7 @@ proc getXdgEnv*(input: Input): XdgEnv =
         error &"equinox: equinox path is defined at compile-time, but '{equinoxBin}' is not exist"
         quit(1)
       equinoxBin
-    elif (let bin = findExe("equinox"); exe != ""):
+    elif (let bin = findExe("equinox"); bin.len > 0):
       bin
     else:
       error &"equinox: cannot find equinox bin, is your installation broken?"


### PR DESCRIPTION
Fixes how the GTK app resolves `equinox`.
1. Checks if `EQUINOX_BIN` exists and the value of it is a file.
2. If failed, then checks if it's compiled with `equinoxBin` and the value of it is a file.
3. If also failed, then find the bin.
4. If non of those resolved, then throws an error.