### PR TITLE
Update BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -53,7 +53,7 @@ You'll need to run this every reboot.
 ## Ubuntu
 Run the following command to gather all dependencies needed by Equinox on Ubuntu.
 ```
-# apt-get update && apt-get install clang make gtk4 libgtk-4-dev libadwaita-1 libadwaita-1-dev pcre2 libpcre2-dev glib2.0 libglib2.0-dev lxc lxc-templates uidmap lxc-utils bridge-utils dnsmasq
+# apt-get update && apt-get install clang make gtk4 libgtk-4-dev libadwaita-1 libadwaita-1-dev pcre2 libpcre2-dev glib2.0 libglib2.0-dev libglibutil-dev lxc lxc-templates uidmap lxc-utils bridge-utils dnsmasq
 ```
 
 Now, unfortunately, just like Fedora, Ubuntu does not have a libgbinder package in its repositories. You'll need to manually clone the repository and compile it instead.


### PR DESCRIPTION
Add libglibutil-dev. This is needed, because without it, libgbinder does NOT compile on Ubuntu:


`Package libglibutil was not found in the pkg-config search path.
Perhaps you should add the directory containing 'libglibutil.pc'
to the PKG_CONFIG_PATH environment variable
Package 'libglibutil', required by 'virtual:world', not found
make: *** [Makefile:267: build/debug/gbinder_buffer.o] Error 1
make: *** Waiting for unfinished jobs....
In file included from src/gbinder_cleanup.c:33:
In file included from src/gbinder_cleanup.h:36:
In file included from src/gbinder_types_p.h:36:
include/gbinder_types.h:36:10: fatal error: 'gutil_types.h' file not found
   36 | #include <gutil_types.h>
      |          ^~~~~~~~~~~~~~~
`